### PR TITLE
Adding a tab plugin and basic focus tests.

### DIFF
--- a/cypress/integration/indexCards_spec.js
+++ b/cypress/integration/indexCards_spec.js
@@ -1,3 +1,5 @@
+require('cypress-plugin-tab');
+
 describe('Smoke test', function() {
   it('Asserts tests load', () => {
     expect(true).to.equal(true);
@@ -12,6 +14,12 @@ describe('First real test', () => {
     cy.get('article[aria-labelledby="header-1"]').contains('h2', 'Shaun of the Dead');
     cy.get('article[aria-labelledby="header-2"]').contains('h2', 'The Dark Knight');
     cy.get('article[aria-labelledby="header-3"]').contains('h2', 'Watchmen');
+    cy.get('body').tab();
+    cy.focused().should('have.id', 'card-1-id');
+    cy.focused().tab();
+    cy.focused().should('have.id', 'card-2-id');
+    cy.focused().tab();
+    cy.focused().should('have.id', 'card-3-id');
   });
 });
 

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
           <dl>
             <div>
               <dt>
-                <a href="https://www.imdb.com/title/tt0365748/">Shaun of the
+                <a id="card-1-id" href="https://www.imdb.com/title/tt0365748/">Shaun of the
                   Dead: IMDB</a>
               </dt>
               <dd>
@@ -49,7 +49,7 @@
           <dl>
             <div>
               <dt>
-                <a href="https://www.imdb.com/title/tt0468569/?ref_=nv_sr_1?ref_=nv_sr_1">The Dark Knight: IMDB</a>
+                <a id="card-2-id" href="https://www.imdb.com/title/tt0468569/?ref_=nv_sr_1?ref_=nv_sr_1">The Dark Knight: IMDB</a>
               </dt>
               <dd>
                 <dfn>Genre</dfn>
@@ -78,7 +78,7 @@
           <dl>
             <div>
               <dt>
-                <a href="@https://www.imdb.com/title/tt0409459/?ref_=nv_sr_2?ref_=nv_sr_2">Watchmen: IMDB</a>
+                <a id="card-3-id" href="@https://www.imdb.com/title/tt0409459/?ref_=nv_sr_2?ref_=nv_sr_2">Watchmen: IMDB</a>
               </dt>
               <dd>
                 <dfn>Genre</dfn>

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,16 @@
         "uri-js": "^4.2.2"
       }
     },
+    "ally.js": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/ally.js/-/ally.js-1.4.1.tgz",
+      "integrity": "sha1-n7fmuljvrE7pExyymqnuO1QLzx4=",
+      "dev": true,
+      "requires": {
+        "css.escape": "^1.5.0",
+        "platform": "1.3.3"
+      }
+    },
     "ansi-escapes": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
@@ -321,6 +331,12 @@
         "which": "^1.2.9"
       }
     },
+    "css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
+      "dev": true
+    },
     "cypress": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.4.1.tgz",
@@ -357,6 +373,15 @@
         "tmp": "0.1.0",
         "url": "0.11.0",
         "yauzl": "2.10.0"
+      }
+    },
+    "cypress-plugin-tab": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cypress-plugin-tab/-/cypress-plugin-tab-1.0.3.tgz",
+      "integrity": "sha512-uiadGT+IzoGxKCqYxQXyc5OhHkv4JAT5LWwNTs8R6pBJkBUUC/uZR2ys4jqhqX6mD/ZucAt5p+U9KMr8Ae4fQA==",
+      "dev": true,
+      "requires": {
+        "ally.js": "^1.4.1"
       }
     },
     "dashdash": {
@@ -1183,6 +1208,12 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "platform": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.3.tgz",
+      "integrity": "sha1-ZGx3ARiZhwtqCQPnXpl+jlHadGE=",
       "dev": true
     },
     "process-nextick-args": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/1Copenut/cypress-test#readme",
   "devDependencies": {
-    "cypress": "^3.4.1"
+    "cypress": "^3.4.1",
+    "cypress-plugin-tab": "^1.0.3"
   }
 }


### PR DESCRIPTION
Cypress doesn't include a native tab keypress, so I found a [plugin cypress-plugin-tab](https://github.com/Bkucera/cypress-plugin-tab) that filled in the missing functionality. I added a proof of concept for keyboard focus testing.