### PR TITLE
[FEATURE] Adding Dockerfile recipe and shell script for CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM node:20.9.0-slim
 
 WORKDIR /app
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # Install Cypress prerequisites
 RUN apt-get update \
   && apt-get install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libnss3 libxss1 libasound2 libxtst6 xauth xvfb --no-install-recommends -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM node:18.18.1-slim
+
+RUN apt-get update \
+  && apt-get install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libnss3 libxss1 libasound2 libxtst6 xauth xvfb --no-install-recommends -y \
+  && apt-get upgrade -y \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists*
+
+COPY package*.json ./
+
+RUN npm install
+
+COPY . .
+
+# Add the Cypress permissions
+RUN usermod -a -G audio,video node \
+  && mkdir -p /app \
+  && mkdir -p /cypress/screenshots \
+  && mkdir -p /cypress/videos \
+  && chown -R node:node /cypress \
+  && chown -R node:node /app
+
+USER node
+
+WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,39 @@
-FROM node:18.18.1-slim
+FROM node:20.9.0-slim
 
+WORKDIR /app
+
+# Install Cypress prerequisites
 RUN apt-get update \
   && apt-get install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libnss3 libxss1 libasound2 libxtst6 xauth xvfb --no-install-recommends -y \
   && apt-get upgrade -y \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists*
 
+# Install latest chrome package and update libs
+RUN apt-get update \
+  && apt-get install -y wget xvfb ca-certificates gnupg \
+  --no-install-recommends \
+  && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+  && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list \
+  && apt-get update \
+  && apt-get install -y google-chrome-stable \
+  --no-install-recommends \
+  && apt-get upgrade -y \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* \
+  && rm -rf /src/*.deb
+
 COPY package*.json ./
 
-RUN npm install
-
-COPY . .
-
-# Add the Cypress permissions
+# Add Cypress and directory permissions
 RUN usermod -a -G audio,video node \
   && mkdir -p /app \
-  && mkdir -p /cypress/screenshots \
-  && mkdir -p /cypress/videos \
-  && chown -R node:node /cypress \
+  && mkdir -p /app/cypress/screenshots \
+  && mkdir -p /app/cypress/videos \
   && chown -R node:node /app
 
 USER node
 
-WORKDIR /app
+RUN npm install
+
+CMD ["google-chrome-stable"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "axe-core": "^4.8.2",
-        "cypress": "^13.3.1",
+        "cypress": "^13.6.0",
         "cypress-axe": "^1.5.0",
         "cypress-real-events": "^1.10.3",
         "http-server": "^14.1.0",
@@ -647,9 +647,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "13.3.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.3.1.tgz",
-      "integrity": "sha512-g4mJLZxYN+UAF2LMy3Znd4LBnUmS59Vynd81VES59RdW48Yt+QtR2cush3melOoVNz0PPbADpWr8DcUx6mif8Q==",
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.6.0.tgz",
+      "integrity": "sha512-quIsnFmtj4dBUEJYU4OH0H12bABJpSujvWexC24Ju1gTlKMJbeT6tTO0vh7WNfiBPPjoIXLN+OUqVtiKFs6SGw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2976,9 +2976,9 @@
       }
     },
     "cypress": {
-      "version": "13.3.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.3.1.tgz",
-      "integrity": "sha512-g4mJLZxYN+UAF2LMy3Znd4LBnUmS59Vynd81VES59RdW48Yt+QtR2cush3melOoVNz0PPbADpWr8DcUx6mif8Q==",
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.6.0.tgz",
+      "integrity": "sha512-quIsnFmtj4dBUEJYU4OH0H12bABJpSujvWexC24Ju1gTlKMJbeT6tTO0vh7WNfiBPPjoIXLN+OUqVtiKFs6SGw==",
       "dev": true,
       "requires": {
         "@cypress/request": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/1Copenut/cypress-test#readme",
   "devDependencies": {
     "axe-core": "^4.8.2",
-    "cypress": "^13.3.1",
+    "cypress": "^13.6.0",
     "cypress-axe": "^1.5.0",
     "cypress-real-events": "^1.10.3",
     "http-server": "^14.1.0",

--- a/scripts/docker-cypress.sh
+++ b/scripts/docker-cypress.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+DOCKER_IMAGE_URL=YOUR_IMAGE_URL
+
+docker run -it --rm -v "$PWD":/app "$DOCKER_IMAGE" bash -c 'npm run cypress:ci'


### PR DESCRIPTION
The Dockerfile is ready but the image hasn't been pushed to Docker Hub just yet. I added a stub `DOCKER_IMAGE_URL` in the shell script so I can add it easily. Once that's in place, the next step will be to run the Cypress tests on pull request using GHA. PR closes #38.